### PR TITLE
Prevent a crash by NullPointerException in PLService.onStartCommand

### DIFF
--- a/Android/PimaticLocation/app/src/main/java/de/blackoise/pimaticlocation/PLService.java
+++ b/Android/PimaticLocation/app/src/main/java/de/blackoise/pimaticlocation/PLService.java
@@ -76,7 +76,7 @@ public class PLService extends Service implements GoogleApiClient.ConnectionCall
     public int onStartCommand(Intent intent, int flags, int startId) {
         Log.v("PLService", "Service started.");
         final SharedPreferences settings = getSharedPreferences("de.blackoise.pimaticlocation", MODE_PRIVATE);
-        if (Intent.ACTION_SEND.equals(intent.getAction()) && intent.getType() != null) {
+        if (intent != null && Intent.ACTION_SEND.equals(intent.getAction()) && intent.getType() != null) {
             writeLog("Intent with type " + intent.getType()+" received.");
             if ("text/plain".equals(intent.getType())) {
                 Bundle extras = intent.getExtras();


### PR DESCRIPTION
Without the check it crashes randomly / when closing the app in task switcher (nexus 5 Android 5)

```
03-04 21:58:32.328  19156-19156/de.blackoise.pimaticlocation E/AndroidRuntime﹕ FATAL EXCEPTION: main
    Process: de.blackoise.pimaticlocation, PID: 19156
    java.lang.RuntimeException: Unable to start service de.blackoise.pimaticlocation.PLService@3ad9d047 with null: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.content.Intent.getAction()' on a null object reference
            at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:2881)
            at android.app.ActivityThread.access$2100(ActivityThread.java:144)
            at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1376)
            at android.os.Handler.dispatchMessage(Handler.java:102)
            at android.os.Looper.loop(Looper.java:135)
            at android.app.ActivityThread.main(ActivityThread.java:5221)
            at java.lang.reflect.Method.invoke(Native Method)
            at java.lang.reflect.Method.invoke(Method.java:372)
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:899)
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:694)
     Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.content.Intent.getAction()' on a null object reference
            at de.blackoise.pimaticlocation.PLService.onStartCommand(PLService.java:79)
            at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:2864)
            at android.app.ActivityThread.access$2100(ActivityThread.java:144)
            at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1376)
            at android.os.Handler.dispatchMessage(Handler.java:102)
            at android.os.Looper.loop(Looper.java:135)
            at android.app.ActivityThread.main(ActivityThread.java:5221)
            at java.lang.reflect.Method.invoke(Native Method)
            at java.lang.reflect.Method.invoke(Method.java:372)
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:899)
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:694)
```
